### PR TITLE
Uniqueness Bean Validation

### DIFF
--- a/src/main/java/org/cejug/hurraa/model/EquipmentType.java
+++ b/src/main/java/org/cejug/hurraa/model/EquipmentType.java
@@ -27,12 +27,14 @@ import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 
 import org.cejug.hurraa.validation.EquipmentTypeNameAvailable;
+import org.cejug.hurraa.validation.Unique;
 import org.hibernate.validator.constraints.NotBlank;
 
 @NamedQueries({
     @NamedQuery(name="NAME_IN_USE" , query="FROM EquipmentType e WHERE e.name = :name")
 })
 @Entity
+@Unique(propertyName = "name" , identityPropertyName = "id" , entityClass = EquipmentType.class)
 public class EquipmentType {
 	
 	@Id
@@ -40,7 +42,6 @@ public class EquipmentType {
 	private Long id;
 	
 	@NotBlank
-	@EquipmentTypeNameAvailable
 	private String name;
 	
 	@Override

--- a/src/main/java/org/cejug/hurraa/validation/CejugMethodValidator.java
+++ b/src/main/java/org/cejug/hurraa/validation/CejugMethodValidator.java
@@ -54,12 +54,30 @@ public class CejugMethodValidator extends MethodValidator {
 		Iterator<Node> node = violation.getPropertyPath().iterator();
 		int index =  getFirstParameterIndex( node );  
 		node = violation.getPropertyPath().iterator();// Reset the interator
-		return mountCategory( node ).replace( "arg" + index , params[index].getName() );
+		StringBuilder joinedCategoryBuilder = new StringBuilder( mountCategory( node ).replace( "arg" + index , params[index].getName() ) );
+		return appendPropertyNameIfDefined( joinedCategoryBuilder , violation ) ;
 	}
 	
 	private String mountCategory( Iterator<Node> node ){
 		ignoreMethodName( node );
-		return Joiner.on(".").join( node );
+		String joined = Joiner.on(".").join( node );
+		return removeLastDotIndexIfAny(joined);
+	}
+	
+	private String removeLastDotIndexIfAny(String joined){
+	    int lastDotIndex = joined.lastIndexOf('.');
+        if( lastDotIndex == ( joined.length() - 1 )  ){
+            joined = joined.substring( 0 , lastDotIndex );
+        }
+        return joined;
+	}
+	
+	private String appendPropertyNameIfDefined( StringBuilder joinedCategoryBuilder  , ConstraintViolation<Object> violation ){
+	    Object propertyName = violation.getConstraintDescriptor().getAttributes().get("propertyName");
+	    if( propertyName != null){
+	        joinedCategoryBuilder.append(".").append( propertyName );
+	    }
+	    return joinedCategoryBuilder.toString();
 	}
 	
 	private void ignoreMethodName( Iterator<Node> node ){

--- a/src/main/java/org/cejug/hurraa/validation/Unique.java
+++ b/src/main/java/org/cejug/hurraa/validation/Unique.java
@@ -1,0 +1,34 @@
+package org.cejug.hurraa.validation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import javax.validation.ReportAsSingleViolation;
+
+import org.cejug.hurraa.validation.impl.UniqueValidator;
+
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = { UniqueValidator.class })
+@ReportAsSingleViolation
+@Documented
+public @interface Unique {
+    
+    String message() default "{already_in_use}";
+    
+    String propertyName();
+    
+    String identityPropertyName();
+    
+    Class entityClass();
+ 
+    Class<?>[] groups() default {};
+ 
+    Class<? extends Payload>[] payload() default {};
+    
+}

--- a/src/main/java/org/cejug/hurraa/validation/impl/UniqueValidator.java
+++ b/src/main/java/org/cejug/hurraa/validation/impl/UniqueValidator.java
@@ -1,0 +1,99 @@
+/*
+* Hurraa is a web application conceived to manage resources
+* in companies that need manage IT resources. Create issues
+* and purchase IT materials. Copyright (C) 2014 CEJUG.
+*
+* Hurraa is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* Hurraa is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Hurraa. If not, see http://www.gnu.org/licenses/gpl-3.0.html.
+*
+*/
+package org.cejug.hurraa.validation.impl;
+
+import java.lang.reflect.Field;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.PersistenceUnit;
+import javax.persistence.Query;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+import org.cejug.hurraa.validation.Unique;
+
+/**
+ * 
+ * @author Efraim Gentil (efraim.gentil@gmail.com)
+ * 
+ */
+public class UniqueValidator implements ConstraintValidator< Unique  ,  Object > {
+    
+//  @PersistenceContext
+//  private EntityManager entityManager;
+
+    @PersistenceUnit
+    private EntityManagerFactory entityManagerFactory;
+    
+    private String fieldName;
+    private String identityFieldName;
+    private Class entityClass;
+    
+    @Override
+    public void initialize(Unique constraintAnnotation) {
+        fieldName = constraintAnnotation.propertyName();
+        identityFieldName = constraintAnnotation.identityPropertyName();
+        entityClass = constraintAnnotation.entityClass();
+    }
+    
+    @Override
+    public boolean isValid(Object value,
+            ConstraintValidatorContext context) {
+        return testeHaduken(value, context);
+    }
+    
+    public boolean testeHaduken(Object value,
+            ConstraintValidatorContext context){
+        try {
+            Field field = value.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            Object fieldValue = field.get(value);
+            
+            field = value.getClass().getDeclaredField( identityFieldName );
+            field.setAccessible(true);
+            Object identityFieldValue = field.get(value);
+            
+            
+            StringBuilder sb = new StringBuilder( String.format( "FROM %s a WHERE  a.%s = :fieldValue" , entityClass.getSimpleName() , fieldName ) );
+            if(identityFieldValue != null)
+               sb.append( String.format( " AND a.%s != :identifyFieldValue"  , identityFieldName ) );   
+            
+            EntityManager entityManager = entityManagerFactory.createEntityManager();
+            
+            Query query = entityManager.createQuery( sb.toString() );
+            query.setMaxResults(1);
+            query.setParameter( "fieldValue", fieldValue );
+            if(identityFieldValue != null)
+                query.setParameter( "identifyFieldValue", identityFieldValue );
+            
+            return query.getResultList().isEmpty();
+        } catch (IllegalArgumentException | IllegalAccessException e) {
+            e.printStackTrace();
+        } catch (NoSuchFieldException e) {
+            e.printStackTrace();
+        } catch (SecurityException e) {
+            e.printStackTrace();
+        }
+        
+        return false;
+    }
+
+}

--- a/src/main/webapp/WEB-INF/jsp/equipmentType/form.jsp
+++ b/src/main/webapp/WEB-INF/jsp/equipmentType/form.jsp
@@ -31,8 +31,8 @@
             </h1>
         </div>
     </c:if>
-
-    <div style="width: 50%;">
+    
+    <div style="width: 50%;"> 
         <form action="${action}" method="post">
             <fieldset>
                 <cejug:textFieldVertical name="equipmentType.name"


### PR DESCRIPTION
- Addition of @Unique to handle uniqueness validation see example in EquipmentType model.

The annotation required 3 parameters,
1. propertyName , represents the property you want to verify uniqueness also needed to specify which field the error message will be linked.
2. identityPropertyName, represents the identity of the entity, is used to handle update actions
3. entityClass, Used to identify the entity that will be verified in the database, and to access the attributes with reflection.

The annotation can be placed in two places, in the type of the entity ( the class declaration ) , but it will trigger the validation two times, one for the @Valid annotation the second when it going to be persisted it will trigger again the validation.
Or you can place in the parameter that represent the type you want to validate in a controller method, it will trigger the validation only one time, but you have to put in all the methods that you want to make the validation. 

The point that you need to annotate the type its because you need to access differents fields of the class like the id, to verify the uniqueness on a update action.

Open to discussion.
